### PR TITLE
Exclude Node >=16 from valid versions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 	},
 	"license": "MIT",
 	"engines": {
-		"node": ">=10.0.0"
+		"node": ">=10.0.0 <16"
 	},
 	"dependencies": {
 		"detect-libc": "^1.0.3"


### PR DESCRIPTION
This should block the install of fibers on node 16.